### PR TITLE
Feature: Restrict user to claim rewards until the specified delay 

### DIFF
--- a/contracts/Config.sol
+++ b/contracts/Config.sol
@@ -9,6 +9,7 @@ contract Config {
         uint256 rewards;
         uint256 stakeTime;
         uint256 unstakeTime;
+        uint256 rewardsClaimedTime;
     }
 
     address[] public stakers;
@@ -17,6 +18,7 @@ contract Config {
     IERC20 internal token;
     uint256 public apy;
     uint256 public unbondingPeriod;
+    uint256 public claimDelay;
     uint256 internal constant ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
     uint256 internal constant PERCENTAGE_MULTIPLIER = 100;
 }

--- a/contracts/IStaking.sol
+++ b/contracts/IStaking.sol
@@ -21,5 +21,7 @@ interface IStaking {
 
     function updateAPY(uint256 _apy) external;
 
+    function updateClaimDelay(uint256 _claimDelay) external;
+
     function updateUnbondingPeriod(uint256 _unbondingPeriod) external;
 }

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,4 @@ Features
   - Usecase 1 - After staking user will be able to claim rewards delay period is over.
   - Usecase 2 - If user claim rewards on 10th then the user will be eligible on 21st.
   - Usecase 3 - If user claim rewards after 15days then the user will be eligible to claim rewards after (last claim time + delay period).
+  - Usecase 4 - Unstake without unbonding period with some amount of fee. 


### PR DESCRIPTION
Add claim delay which will restrict the user to claim rewards before the delay get's over and claim delay gets updated once user claim rewards. Moreover, it can be changed by owner also.

Test Coverage 
![image](https://user-images.githubusercontent.com/18752215/128753095-d2c42d12-b077-43ad-b28c-db549099c13a.png)
